### PR TITLE
REAMDE.md is missing the basic build information

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ Run Local (in-memory)
 Run Local in production mode
 
 	$ export SPRING_PROFILES_ACTIVE=prod
-	$ java -jar build/target/server.jar
+	$ java -jar build/target/server.jar	


### PR DESCRIPTION
## Problem
REAMDE.md is missing the basic build information, needed for anybody else to build the product.
## Root Cause
NYI 
## Solution
Simply update the  README.md` with the basic build info